### PR TITLE
feat: implement MERN auth system with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
-node_modules/
+**/.env
+node_modules
+dist
+coverage

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000

--- a/client/package.json
+++ b/client/package.json
@@ -7,25 +7,30 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest --run"
   },
   "dependencies": {
+    "axios": "^1.7.7",
     "framer-motion": "^12.23.12",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "react-router-dom": "^7.7.1"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
     "@testing-library/jest-dom": "^6.6.4",
-    "@types/react": "^19.1.8",
-    "@types/react-dom": "^19.1.6",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.23",
     "@vitejs/plugin-react": "^4.6.0",
     "eslint": "^9.30.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
     "jsdom": "^26.1.0",
+    "msw": "^2.3.1",
     "sass": "^1.89.2",
     "vite": "^7.0.4",
     "vitest": "^3.2.4"

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,6 +5,8 @@ import Home from "./pages/Home.jsx";
 import About from "./pages/About.jsx";
 import Login from "./pages/Login.jsx";
 import Register from "./pages/Register.jsx";
+import Dashboard from "./pages/Dashboard.jsx";
+import PrivateRoute from "./components/PrivateRoute.jsx";
 
 const App = () => (
   <>
@@ -14,9 +16,9 @@ const App = () => (
       <Route path="/about" element={<About />} />
       <Route path="/login" element={<Login />} />
       <Route path="/register" element={<Register />} />
+      <Route path="/dashboard" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
     </Routes>
   </>
 );
 
 export default App;
-

--- a/client/src/__tests__/auth.spec.jsx
+++ b/client/src/__tests__/auth.spec.jsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { AuthProvider } from '../context/AuthContext.jsx';
+import Login from '../pages/Login.jsx';
+import Dashboard from '../pages/Dashboard.jsx';
+import PrivateRoute from '../components/PrivateRoute.jsx';
+
+const server = setupServer(
+  rest.get('/api/auth/me', (_req, res, ctx) => res(ctx.status(401))),
+  rest.post('/api/auth/login', (_req, res, ctx) =>
+    res(ctx.json({ user: { id: '1', name: 'Test', email: 'test@example.com' } }))
+  )
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+test('renders login form', () => {
+  render(
+    <AuthProvider>
+      <MemoryRouter initialEntries={['/login']}>
+        <Login />
+      </MemoryRouter>
+    </AuthProvider>
+  );
+  expect(screen.getByPlaceholderText(/email/i)).toBeInTheDocument();
+});
+
+test('successful login flow', async () => {
+  render(
+    <AuthProvider>
+      <MemoryRouter initialEntries={['/login']}>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/dashboard" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthProvider>
+  );
+  await userEvent.type(screen.getByPlaceholderText(/email/i), 'test@example.com');
+  await userEvent.type(screen.getByPlaceholderText(/password/i), 'password123');
+  await userEvent.click(screen.getByRole('button', { name: /login/i }));
+  await waitFor(() => expect(screen.getByText(/dashboard/i)).toBeInTheDocument());
+});
+
+test('displays error on failed login', async () => {
+  server.use(
+    rest.post('/api/auth/login', (_req, res, ctx) => res(ctx.status(400), ctx.json({ message: 'Invalid credentials' })))
+  );
+  render(
+    <AuthProvider>
+      <MemoryRouter initialEntries={['/login']}>
+        <Login />
+      </MemoryRouter>
+    </AuthProvider>
+  );
+  await userEvent.type(screen.getByPlaceholderText(/email/i), 'test@example.com');
+  await userEvent.type(screen.getByPlaceholderText(/password/i), 'wrongpass');
+  await userEvent.click(screen.getByRole('button', { name: /login/i }));
+  await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Invalid credentials'));
+});
+
+test('PrivateRoute blocks unauthenticated user', async () => {
+  render(
+    <AuthProvider>
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route path="/dashboard" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
+          <Route path="/login" element={<div>Login Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthProvider>
+  );
+  await waitFor(() => expect(screen.getByText('Login Page')).toBeInTheDocument());
+});

--- a/client/src/components/PrivateRoute.jsx
+++ b/client/src/components/PrivateRoute.jsx
@@ -1,0 +1,10 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+
+const PrivateRoute = ({ children }) => {
+  const { user, loading } = useAuth();
+  if (loading) return <div>Loading...</div>;
+  return user ? children : <Navigate to="/login" />;
+};
+
+export default PrivateRoute;

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -1,0 +1,46 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import api from '../services/api.js';
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchMe = async () => {
+      try {
+        const res = await api.get('/api/auth/me');
+        setUser(res.data.user);
+      } catch {
+        setUser(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchMe();
+  }, []);
+
+  const login = async (data) => {
+    const res = await api.post('/api/auth/login', data);
+    setUser(res.data.user);
+  };
+
+  const register = async (data) => {
+    const res = await api.post('/api/auth/register', data);
+    setUser(res.data.user);
+  };
+
+  const logout = async () => {
+    await api.post('/api/auth/logout');
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,12 +3,14 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import "./main.styles.scss";
 import App from "./App.jsx";
+import { AuthProvider } from "./context/AuthContext.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </StrictMode>
 );
-

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,0 +1,14 @@
+import { useAuth } from '../context/AuthContext.jsx';
+
+const Dashboard = () => {
+  const { user, logout } = useAuth();
+  return (
+    <section style={{ padding: '2rem', textAlign: 'center' }}>
+      <h1>Dashboard</h1>
+      <p>Welcome {user?.name}</p>
+      <button onClick={logout}>Logout</button>
+    </section>
+  );
+};
+
+export default Dashboard;

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,10 +1,52 @@
-import React from "react";
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+import './auth.styles.scss';
 
-const Login = () => (
-  <section style={{ padding: "2rem", textAlign: "center" }}>
-    <h1>Login</h1>
-  </section>
-);
+const Login = () => {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [error, setError] = useState(null);
+
+  const handleChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      await login(form);
+      navigate('/dashboard');
+    } catch (err) {
+      setError(err.response?.data?.message || 'Login failed');
+    }
+  };
+
+  return (
+    <section className="auth-wrapper">
+      <div className="auth-card">
+        <h1>Login</h1>
+        <form onSubmit={handleSubmit}>
+          <input
+            placeholder="Email"
+            name="email"
+            type="email"
+            value={form.email}
+            onChange={handleChange}
+          />
+          <input
+            placeholder="Password"
+            name="password"
+            type="password"
+            value={form.password}
+            onChange={handleChange}
+          />
+          {error && <p role="alert">{error}</p>}
+          <button type="submit">Login</button>
+        </form>
+      </div>
+    </section>
+  );
+};
 
 export default Login;
-

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -1,10 +1,59 @@
-import React from "react";
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+import './auth.styles.scss';
 
-const Register = () => (
-  <section style={{ padding: "2rem", textAlign: "center" }}>
-    <h1>Register</h1>
-  </section>
-);
+const Register = () => {
+  const { register } = useAuth();
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ name: '', email: '', password: '' });
+  const [error, setError] = useState(null);
+
+  const handleChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      await register(form);
+      navigate('/dashboard');
+    } catch (err) {
+      setError(err.response?.data?.message || 'Registration failed');
+    }
+  };
+
+  return (
+    <section className="auth-wrapper">
+      <div className="auth-card">
+        <h1>Register</h1>
+        <form onSubmit={handleSubmit}>
+          <input
+            placeholder="Name"
+            name="name"
+            type="text"
+            value={form.name}
+            onChange={handleChange}
+          />
+          <input
+            placeholder="Email"
+            name="email"
+            type="email"
+            value={form.email}
+            onChange={handleChange}
+          />
+          <input
+            placeholder="Password"
+            name="password"
+            type="password"
+            value={form.password}
+            onChange={handleChange}
+          />
+          {error && <p role="alert">{error}</p>}
+          <button type="submit">Register</button>
+        </form>
+      </div>
+    </section>
+  );
+};
 
 export default Register;
-

--- a/client/src/pages/auth.styles.scss
+++ b/client/src/pages/auth.styles.scss
@@ -1,0 +1,50 @@
+.auth-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 4rem);
+  padding: 1rem;
+}
+
+.auth-card {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-card h1 {
+  color: var(--primary-color);
+  text-align: center;
+}
+
+.auth-card form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.auth-card input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.auth-card button {
+  padding: 0.5rem;
+  border: none;
+  border-radius: 4px;
+  background: var(--primary-color);
+  color: #fff;
+  cursor: pointer;
+}
+
+.auth-card p[role='alert'] {
+  color: #e11d48;
+  font-size: 0.875rem;
+}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000',
+  withCredentials: true,
+});
+
+export default api;

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -1,0 +1,8 @@
+import { expect, afterEach } from 'vitest';
+import matchers from '@testing-library/jest-dom/matchers';
+import { cleanup } from '@testing-library/react';
+
+expect.extend(matchers);
+afterEach(() => {
+  cleanup();
+});

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,7 +1,19 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_URL || 'http://localhost:5000',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.js',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "client": "npm run dev --prefix client"
+    "dev": "concurrently \"npm:server\" \"npm:client\"",
+    "server": "npm --prefix server run dev",
+    "client": "npm --prefix client run dev",
+    "test": "concurrently \"npm --prefix server test\" \"npm --prefix client test\""
   },
   "repository": {
     "type": "git",
@@ -17,5 +19,8 @@
     "url": "https://github.com/kofiarhin/color-palette-vault/issues"
   },
   "homepage": "https://github.com/kofiarhin/color-palette-vault#readme",
-  "description": ""
+  "description": "",
+  "devDependencies": {
+    "concurrently": "^9.0.0"
+  }
 }

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,4 @@
+MONGO_URI=mongodb://127.0.0.1:27017/devkofi
+JWT_SECRET=supersecret
+JWT_EXPIRES_IN=7d
+PORT=5000

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+};

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "main": "src/index.js",
+  "scripts": {
+    "dev": "nodemon src/index.js",
+    "start": "node src/index.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.19.2",
+    "express-validator": "^7.0.1",
+    "helmet": "^7.0.0",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^8.5.0",
+    "morgan": "^1.10.0",
+    "ms": "^2.1.3"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "mongodb-memory-server": "^10.1.4",
+    "nodemon": "^3.1.0",
+    "supertest": "^6.3.4"
+  }
+}

--- a/server/src/config/db.js
+++ b/server/src/config/db.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const connectDB = async () => {
+  const uri = process.env.MONGO_URI || 'mongodb://127.0.0.1:27017/devkofi';
+  try {
+    await mongoose.connect(uri, {});
+  } catch (err) {
+    console.error('Mongo connection error', err);
+    process.exit(1);
+  }
+};
+
+module.exports = connectDB;

--- a/server/src/controllers/auth.controller.js
+++ b/server/src/controllers/auth.controller.js
@@ -1,0 +1,77 @@
+const { body, validationResult } = require('express-validator');
+const jwt = require('jsonwebtoken');
+const ms = require('ms');
+const User = require('../models/User');
+
+const signToken = (res, user, status) => {
+  const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, {
+    expiresIn: process.env.JWT_EXPIRES_IN,
+  });
+  const isProd = process.env.NODE_ENV === 'production';
+  res.cookie('token', token, {
+    httpOnly: true,
+    secure: isProd,
+    sameSite: 'lax',
+    maxAge: ms(process.env.JWT_EXPIRES_IN || '7d'),
+  });
+  return res.status(status).json({
+    success: true,
+    user: { id: user._id, name: user.name, email: user.email },
+  });
+};
+
+exports.register = [
+  body('name').notEmpty().withMessage('Name is required'),
+  body('email').isEmail().withMessage('Valid email is required').normalizeEmail(),
+  body('password').isLength({ min: 8 }).withMessage('Password must be at least 8 characters'),
+  async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ success: false, message: 'Validation error', errors: errors.array() });
+    }
+    const { name, email, password } = req.body;
+    try {
+      let user = await User.findOne({ email });
+      if (user) {
+        return res.status(400).json({ success: false, message: 'Email already registered' });
+      }
+      user = await User.create({ name, email, password });
+      return signToken(res, user, 201);
+    } catch (err) {
+      return next(err);
+    }
+  },
+];
+
+exports.login = [
+  body('email').isEmail().withMessage('Valid email is required').normalizeEmail(),
+  body('password').notEmpty().withMessage('Password is required'),
+  async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ success: false, message: 'Validation error', errors: errors.array() });
+    }
+    const { email, password } = req.body;
+    try {
+      const user = await User.findOne({ email }).select('+password');
+      if (!user || !(await user.matchPassword(password))) {
+        return res.status(400).json({ success: false, message: 'Invalid credentials' });
+      }
+      return signToken(res, user, 200);
+    } catch (err) {
+      return next(err);
+    }
+  },
+];
+
+exports.logout = (req, res) => {
+  res.cookie('token', '', {
+    httpOnly: true,
+    expires: new Date(0),
+  });
+  return res.status(200).json({ success: true });
+};
+
+exports.getMe = (req, res) => {
+  return res.status(200).json({ success: true, user: req.user });
+};

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const cors = require('cors');
+const helmet = require('helmet');
+const morgan = require('morgan');
+const cookieParser = require('cookie-parser');
+const dotenv = require('dotenv');
+const connectDB = require('./config/db');
+const authRoutes = require('./routes/auth.routes');
+const { errorHandler } = require('./middleware/error');
+
+dotenv.config();
+
+const app = express();
+const clientURL = process.env.CLIENT_URL || 'http://localhost:5173';
+
+app.use(cors({ origin: clientURL, credentials: true }));
+app.use(helmet());
+if (process.env.NODE_ENV === 'development') {
+  app.use(morgan('dev'));
+}
+app.use(express.json({ limit: '50kb' }));
+app.use(cookieParser());
+
+app.use('/api/auth', authRoutes);
+
+app.use(errorHandler);
+
+const PORT = process.env.PORT || 5000;
+
+if (require.main === module) {
+  connectDB().then(() => {
+    app.listen(PORT);
+  });
+}
+
+module.exports = app;

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -1,0 +1,18 @@
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+const auth = async (req, res, next) => {
+  const token = req.cookies.token;
+  if (!token) return res.status(401).json({ success: false, message: 'Not authorized' });
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const user = await User.findById(decoded.id).select('-password');
+    if (!user) return res.status(401).json({ success: false, message: 'Not authorized' });
+    req.user = user;
+    next();
+  } catch (err) {
+    return res.status(401).json({ success: false, message: 'Not authorized' });
+  }
+};
+
+module.exports = auth;

--- a/server/src/middleware/error.js
+++ b/server/src/middleware/error.js
@@ -1,0 +1,10 @@
+const errorHandler = (err, req, res, next) => {
+  const status = res.statusCode !== 200 ? res.statusCode : 500;
+  res.status(status).json({
+    success: false,
+    message: err.message || 'Server Error',
+    errors: err.errors,
+  });
+};
+
+module.exports = { errorHandler };

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -1,0 +1,29 @@
+const mongoose = require('mongoose');
+const bcrypt = require('bcryptjs');
+
+const userSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+    },
+    password: { type: String, required: true, minlength: 8, select: false },
+  },
+  { timestamps: true }
+);
+
+userSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) return next();
+  const salt = await bcrypt.genSalt(10);
+  this.password = await bcrypt.hash(this.password, salt);
+  next();
+});
+
+userSchema.methods.matchPassword = function (entered) {
+  return bcrypt.compare(entered, this.password);
+};
+
+module.exports = mongoose.model('User', userSchema);

--- a/server/src/routes/auth.routes.js
+++ b/server/src/routes/auth.routes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const { register, login, logout, getMe } = require('../controllers/auth.controller');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.post('/register', register);
+router.post('/login', login);
+router.post('/logout', logout);
+router.get('/me', auth, getMe);
+
+module.exports = router;

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -1,0 +1,113 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const app = require('../src/index');
+
+let mongo;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  process.env.JWT_EXPIRES_IN = '7d';
+  mongo = await MongoMemoryServer.create();
+  const uri = mongo.getUri();
+  await mongoose.connect(uri);
+});
+
+afterEach(async () => {
+  const collections = mongoose.connection.collections;
+  for (const key in collections) {
+    await collections[key].deleteMany();
+  }
+});
+
+afterAll(async () => {
+  await mongoose.connection.close();
+  await mongo.stop();
+});
+
+describe('Auth routes', () => {
+  test('registration success', async () => {
+    const res = await request(app).post('/api/auth/register').send({
+      name: 'Test User',
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.user.email).toBe('test@example.com');
+    expect(res.headers['set-cookie']).toBeDefined();
+  });
+
+  test('registration validation failure', async () => {
+    const res = await request(app).post('/api/auth/register').send({
+      name: '',
+      email: 'bad',
+      password: '123',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('registration duplicate email fails', async () => {
+    await request(app).post('/api/auth/register').send({
+      name: 'Test User',
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    const res = await request(app).post('/api/auth/register').send({
+      name: 'Test User',
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('login success and /me', async () => {
+    await request(app).post('/api/auth/register').send({
+      name: 'Test',
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    const loginRes = await request(app).post('/api/auth/login').send({
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    expect(loginRes.status).toBe(200);
+    const cookie = loginRes.headers['set-cookie'];
+    const meRes = await request(app).get('/api/auth/me').set('Cookie', cookie);
+    expect(meRes.status).toBe(200);
+    expect(meRes.body.user.email).toBe('test@example.com');
+  });
+
+  test('login failure with bad password', async () => {
+    await request(app).post('/api/auth/register').send({
+      name: 'Test',
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    const res = await request(app).post('/api/auth/login').send({
+      email: 'test@example.com',
+      password: 'wrongpass',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('/me requires auth', async () => {
+    const res = await request(app).get('/api/auth/me');
+    expect(res.status).toBe(401);
+  });
+
+  test('logout clears cookie', async () => {
+    await request(app).post('/api/auth/register').send({
+      name: 'Test',
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    const loginRes = await request(app).post('/api/auth/login').send({
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    const cookie = loginRes.headers['set-cookie'];
+    const logoutRes = await request(app).post('/api/auth/logout').set('Cookie', cookie);
+    expect(logoutRes.status).toBe(200);
+    expect(logoutRes.headers['set-cookie'][0]).toMatch(/token=;/);
+  });
+});


### PR DESCRIPTION
## Summary
- add Express server with JWT auth, Mongoose user model and routes
- create React auth context, pages, private routing and improved UI styling
- include Jest & Vitest tests for auth flows
- refine env handling and proxy config

## Testing
- ❌ `npm --prefix server test` (MongoDB binary download 403)
- ❌ `npm --prefix client test` (vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b998f0ae408330b6b04699cee95e76